### PR TITLE
Fix user is not redirected back to site after paypal payment on Edge

### DIFF
--- a/back-end/router/order.ts
+++ b/back-end/router/order.ts
@@ -4,6 +4,7 @@ import paypalConfig from '../config/paypal.config';
 import * as requestPromise from 'request-promise';
 import Order from '../models/orders.model';
 import {authenticate} from 'passport';
+import * as url from 'url';
 
 router.post('/get-token', (req, res) => {
     const orderBody = req.body;
@@ -23,6 +24,8 @@ router.post('/get-token', (req, res) => {
             return response.access_token;
         })
         .then(token => {
+            let referer = url.parse(req.headers['referer']);
+            let returnAddress = referer.protocol + '://' + referer.host;
             const options = {
                 method: 'POST',
                 headers: {
@@ -33,8 +36,8 @@ router.post('/get-token', (req, res) => {
                 body: {
                     "intent": "sale",
                     "redirect_urls": {
-                        "return_url": `${req.headers['origin']}/payment/process`,
-                        "cancel_url": `${req.headers['origin']}/order/failure`
+                        "return_url": `${returnAddress}/payment/process`,
+                        "cancel_url": `${returnAddress}/order/failure`
                     },
                     "payer": {
                         "payment_method": "paypal"


### PR DESCRIPTION
Fixes https://github.com/SMH110/Pizza-website/issues/16

Origin is not mandatory on requests but Referer will be there in our scenario as per the spec. Host is always there in all scenarios but might involve extra logic in determining the protocol ('http' or 'https') so I've gone with Referer for now.