### PR TITLE
E2E test improvements:

### DIFF
--- a/back-end/package.json
+++ b/back-end/package.json
@@ -18,7 +18,6 @@
   "devDependencies": {
     "@types/bcrypt-nodejs": "0.0.30",
     "@types/body-parser": "0.0.33",
-    "@types/chai": "^3.4.34",
     "@types/ejs": "^2.3.33",
     "@types/express": "^4.0.34",
     "@types/jsonwebtoken": "^7.2.0",
@@ -28,7 +27,6 @@
     "@types/passport": "^0.3.2",
     "@types/passport-jwt": "^2.0.19",
     "@types/request-promise": "^4.1.33",
-    "chai": "^3.5.0",
     "node-fetch": "^1.6.3"
   }
 }

--- a/front-end/app/notification.component/order-success.component.html
+++ b/front-end/app/notification.component/order-success.component.html
@@ -1,6 +1,6 @@
 <div class="container">
     <div class="row">
-        <div class="col-md-8 col-md-offset-2 center-text">
+        <div class="col-md-8 col-md-offset-2 center-text order-success">
             <h1>Thank You!</h1>
             <h2><span class="glyphicon glyphicon-ok"></span> Your order was successfully made</h2>
         </div>

--- a/front-end/specs/ordering.specs.ts
+++ b/front-end/specs/ordering.specs.ts
@@ -1,5 +1,5 @@
-import { browser, by, element, ElementFinder } from "protractor";
-import { urlShouldBecome, whenAnyVisible, whenVisible } from './utils';
+import { browser, by, element, ElementFinder, ExpectedConditions as EC } from "protractor";
+import { urlShouldBecome, whenAnyVisible, whenVisible, waitForAngularToLoad } from './utils';
 
 describe("E2E Tests", () => {
     beforeEach(async () => {
@@ -8,7 +8,7 @@ describe("E2E Tests", () => {
     });
 
     it("I can add a pizza, side and drink to the basket and check out using PayPal", async () => {
-        await browser.get('https://godfather-pizza-dev.herokuapp.com/');
+        await browser.get('/');
         
         // Add a pizza
         await addProduct('Neapolitan Pizza');
@@ -39,7 +39,7 @@ describe("E2E Tests", () => {
 
         // Wait for PayPal to load
         await urlShouldBecome(url => /sandbox\.paypal\.com/.test(url));
-        browser.ignoreSynchronization = true;
+        browser.waitForAngularEnabled(false);
 
         // Enter details and pay
         await whenVisible(by.id('login_email'), email => email.sendKeys('csharpandsons-buyer@gmail.com'))
@@ -49,7 +49,11 @@ describe("E2E Tests", () => {
 
         // Ensure we are routed back to /order/success
         await urlShouldBecome(url => /\/order\/success/.test(url));
-        browser.ignoreSynchronization = false;
+        await waitForAngularToLoad();
+        browser.waitForAngularEnabled(true);
+
+        let orderSuccess = element(by.css('.order-success'));
+        await EC.visibilityOf(orderSuccess);
     });
 });
 

--- a/front-end/specs/utils.ts
+++ b/front-end/specs/utils.ts
@@ -4,7 +4,7 @@ const UI_READY_TIMEOUT = 10000;
 const URL_CHANGE_TIMEOUT = 20000;
 
 export async function urlShouldBecome(predicate: (url: string) => boolean) {
-    browser.ignoreSynchronization = true;
+    browser.waitForAngularEnabled(false);
     let lastUrl;
     try {
         await browser.wait(async () => {
@@ -16,7 +16,7 @@ export async function urlShouldBecome(predicate: (url: string) => boolean) {
         console.log(`urlShouldBecome failed. Last URL was ${lastUrl}. Looking for ${predicate.toString()}.`);
         throw e;
     } finally {
-        browser.ignoreSynchronization = false;
+        browser.waitForAngularEnabled(true);
     }
 }
 
@@ -30,4 +30,8 @@ export async function whenAnyVisible<T>(locator: By, action: (element: ElementAr
     await browser.wait(EC.visibilityOf(element(locator)), UI_READY_TIMEOUT);
     let elements = element.all(locator);
     return await action(elements);
+}
+
+export async function waitForAngularToLoad() {
+    await browser.wait(async () => await browser.executeScript("return window.getAngularTestability !== undefined;"), URL_CHANGE_TIMEOUT);
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "start": "node back-end/app.js"
   },
   "dependencies": {
+    "@types/chai": "^3.4.34",
     "@types/mocha": "^2.2.38",
+    "chai": "^3.5.0",
     "mocha": "^3.2.0",
     "protractor": "^5.0.0",
     "typescript": "^2.1.5"


### PR DESCRIPTION
- Check for success at the end of the E2E test
- Move chai to root so it's ready to use in E2E tests
- Run tests against localhost by default
- Use waitForProtractorEnabled() instead of ignoreSynchronization which is now deprecated