### PR TITLE
Add nocache for API endpoints. Also see below:

### DIFF
--- a/back-end/app.ts
+++ b/back-end/app.ts
@@ -24,27 +24,32 @@ import admin from './router/admin';
 import health from './router/health';
 
 const app = express();
-//engine
+const nocache = require('nocache');
+
+// View engine
 app.engine('html', require('ejs').renderFile);
-// view engine
 app.set('view engine', 'ejs')
 app.set('views', path.join(__dirname, 'views'));
-//static
+
+// Static Files
 app.use('/shared', express.static(path.join(__dirname, '..', 'shared')));
 app.use(express.static(path.join(__dirname, '..', 'front-end')));
 
+
+// JSON Requests
 app.use(bodyParser.json())
-app.use(bodyParser.urlencoded({ extended: true }))
 
 // Initialize passport
 app.use(passport.initialize());
 
-app.use('/api/order', order);
-app.use('/api/admin', admin);
-app.use('/api/products', items);
+// Register Routes
+app.use('/api/order', nocache(), order);
+app.use('/api/admin', nocache(), admin);
+app.use('/api/products', nocache(), items);
 app.use('/health', health);
-app.use('/', clientSide);
+app.use(nocache(), clientSide);
 
+// Register Payment Gateways
 initialisePayPalEndpoints(app);
 
 const port = process.env.PORT || 3000;

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -1,8 +1,7 @@
 {
   "name": "pizza-website-back-end",
   "version": "1.0.0",
-  "scripts": {
-  },
+  "scripts": {},
   "dependencies": {
     "bcrypt-nodejs": "0.0.3",
     "body-parser": "^1.15.2",
@@ -10,6 +9,7 @@
     "express": "^4.14.0",
     "jsonwebtoken": "^7.2.1",
     "mongoose": "^4.7.1",
+    "nocache": "^2.0.0",
     "passport": "^0.3.2",
     "passport-jwt": "^2.2.1",
     "request": "^2.79.0",

--- a/front-end/app/notification.component/item-added-notification.component.html
+++ b/front-end/app/notification.component/item-added-notification.component.html
@@ -1,9 +1,3 @@
-<div class="conatiner">
-    <div class="row">
-        <div class="col-md-12">
-            <div class="notification" [class.show]='itemNotification.isNotificationShown'>
-                <strong> {{itemNotification.notificationMessage}}</strong>
-            </div>
-        </div>
-    </div>
+<div class="notification" [class.show]='itemNotification.isNotificationShown'>
+    <strong> {{itemNotification.notificationMessage}}</strong>
 </div>

--- a/front-end/app/notification.component/item-added-notification.component.ts
+++ b/front-end/app/notification.component/item-added-notification.component.ts
@@ -8,16 +8,15 @@ import { ItemNotificationService } from '../service/item-notification.service';
 .notification {
     position: fixed;
     top: 10px;
-    right: 0;
-    width: 300px;
+    right: 10px;
     color: red;
     z-index: 100;
     opacity: 0;
     transition: .5s ease-in-out all;
 }
 
-.show{
-    opacity: 1 !important;
+.notification.show {
+    opacity: 1;
 }
     `]
 

--- a/front-end/app/service/item-notification.service.ts
+++ b/front-end/app/service/item-notification.service.ts
@@ -2,14 +2,16 @@ import { Injectable } from '@angular/core';
 
 @Injectable()
 export class ItemNotificationService {
-    notificationMessage: string = '';
+    notificationMessage: string;
     isNotificationShown: boolean = false;
-    clearNotificationTimer: any;
+    
+    private clearNotificationTimer: NodeJS.Timer;
+
     notify(item: Item): void {
-        this.notificationMessage = '';
         clearTimeout(this.clearNotificationTimer);
         this.notificationMessage = `${item.name} added to your basket`;
         this.isNotificationShown = true;
+        
         this.clearNotificationTimer = setTimeout(() => {
             this.isNotificationShown = false;
         }, 3000);

--- a/specs/e2e/utils.ts
+++ b/specs/e2e/utils.ts
@@ -1,10 +1,9 @@
 import { browser, element, ElementArrayFinder, ElementFinder, ExpectedConditions as EC } from "protractor";
 import { By } from "selenium-webdriver";
-const UI_READY_TIMEOUT = 10000;
+const UI_READY_TIMEOUT = 15000;
 const URL_CHANGE_TIMEOUT = 20000;
 
 export async function urlShouldBecome(predicate: (url: string) => boolean) {
-    browser.waitForAngularEnabled(false);
     let lastUrl;
     try {
         await browser.wait(async () => {
@@ -15,8 +14,6 @@ export async function urlShouldBecome(predicate: (url: string) => boolean) {
     } catch (e) {
         console.log(`urlShouldBecome failed. Last URL was ${lastUrl}. Looking for ${predicate.toString()}.`);
         throw e;
-    } finally {
-        browser.waitForAngularEnabled(true);
     }
 }
 
@@ -32,6 +29,35 @@ export async function whenAnyVisible<T>(locator: By, action: (element: ElementAr
     return await action(elements);
 }
 
+export async function whenVisibleAndNotMoving<T>(locator: By, action: (element: ElementFinder) => T) {
+    return await whenVisible(locator, async element => {
+        let previousLocation = await element.getLocation();
+        let attempts = 0;
+        while (true) {
+            await new Promise(resolve => setTimeout(resolve, 100));
+            let currentLocation = await element.getLocation();
+            if (currentLocation.x === previousLocation.x && currentLocation.y === previousLocation.y) {
+                break;
+            } else {
+                previousLocation = currentLocation;
+                if (attempts++ === 30) {
+                    throw new Error("Element was moving for longer than 3 seconds" + locator.toString());
+                }
+            }
+        }
+        return await action(element);
+    });
+}
+
 export async function waitForAngularToLoad() {
     await browser.wait(async () => await browser.executeScript("return window.getAngularTestability !== undefined;"), URL_CHANGE_TIMEOUT);
+}
+
+export async function doInsideIFrame<T>(locator: By, action: () => T) {
+    browser.switchTo().frame(browser.driver.findElement(locator));
+    try {
+        await action();
+    } finally {
+        browser.switchTo().defaultContent();
+    }
 }


### PR DESCRIPTION
- Remove bodyParser.urlencoded because we don't currently take any requests like that
- Make E2E test more resilient to the PayPal website animations
- Some small simplifications to the item-added-notification stuff
- Completely disable waitForAngular in our E2E tests because we don't need it and it causes us to have to wait for the item added notification to disappear when adding each item, which isn't necessarily what the user would do. See this comment for more info: https://github.com/angular/protractor/issues/3349#issuecomment-274771278
- PayPal seem to have fixed the issue which causes their legacy checkout to load when running E2E tests, so adjust the E2E test accordingly

Fixes https://github.com/SMH110/Pizza-website/issues/70