### PR TITLE
Split TypeScript build. See below:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,6 +204,8 @@ FakesAssemblies/
 *.js
 *.js.map
 !front-end/analytics.js
+!wallaby.conf.js
+!webpack*.js
 
 # Webpack generated
 dist

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,8 @@
     "isShellCommand": true,
     "args": [
         "node_modules/typescript/bin/tsc",
-        "-w"
+        "-w",
+        "--noEmit"
     ],
     "showOutput": "silent",
     "isBackground": true,

--- a/back-end/compile.json
+++ b/back-end/compile.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "noImplicitAny": true,
+        "suppressImplicitAnyIndexErrors": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noEmit": true
+    },
+    "include": [
+        "**/*.ts",
+        "../shared/**/*.ts"
+    ],
+    "exclude": [
+        "node_modules"
+    ]
+}

--- a/front-end/compile.json
+++ b/front-end/compile.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "es5",
-        "module": "commonjs",
+        "module": "es2015",
         "moduleResolution": "node",
         "sourceMap": true,
         "emitDecoratorMetadata": true,
@@ -16,14 +16,14 @@
         "noUnusedParameters": true,
         "noEmit": true,
         "typeRoots": [
-            "node_modules/@types",
-            "back-end/node_modules/@types",
-            "front-end/node_modules/@types"
+            "node_modules/@types"
         ]
     },
+    "include": [
+        "**/*.ts",
+        "../shared/**/*.ts"
+    ],
     "exclude": [
-        "node_modules",
-        "back-end/node_modules",
-        "front-end/node_modules"
+        "node_modules"
     ]
 }

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@types/bootstrap": "^3.3.32",
     "@types/google.analytics": "0.0.28",
-    "@types/jquery": "^2.0.40"
+    "@types/jquery": "^2.0.40",
+    "@types/node": "^7.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,17 +3,16 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "compile": "node node_modules/typescript/bin/tsc",
-    "watch": "node_modules/.bin/webpack --config webpack.dev.js --watch",
-    "package": "node_modules/.bin/webpack --config webpack.prod.js",
+    "watch": "webpack --config webpack.dev.js --watch",
+    "package": "webpack --config webpack.prod.js",
     "install-front-end": "cd front-end && npm install --production && npm install --only=development && cd ..",
     "install-back-end": "cd back-end && npm install --production && npm install --only=development && cd ..",
-    "install": "npm run install-back-end && npm run install-front-end && npm run compile && npm run package",
-    "unit": "node node_modules/mocha/bin/mocha specs/unit/**/*.specs.js",
-    "integration": "node node_modules/mocha/bin/mocha specs/integration/**/*.specs.js",
-    "e2e": "node node_modules/protractor/bin/webdriver-manager update && node node_modules/protractor/bin/protractor specs/e2e/protractor.conf.js",
-    "test": "npm run unit && npm run integration && npm run e2e",
-    "start": "node back-end/app.js"
+    "install": "npm run install-back-end && npm run install-front-end && npm run package",
+    "unit": "mocha --compilers ts:ts-node/register specs/unit/**/*.specs.ts",
+    "integration": "mocha --compilers ts:ts-node/register specs/integration/**/*.specs.ts",
+    "e2e": "webdriver-manager update && ts-node --project specs/compile.json node_modules/protractor/bin/protractor specs/e2e/protractor.conf.ts",
+    "test": "npm run unit && npm run integration",
+    "start": "ts-node --project back-end/compile.json back-end/app.ts"
   },
   "dependencies": {
     "@types/chai": "^3.4.34",
@@ -26,6 +25,7 @@
     "@types/webpack": "^2.2.6",
     "@types/webpack-merge": "0.0.4",
     "angular2-template-loader": "^0.6.0",
+    "awesome-typescript-loader": "^3.0.8",
     "chai": "^3.5.0",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.26.1",
@@ -39,10 +39,10 @@
     "raw-loader": "^0.5.1",
     "sass-loader": "^6.0.1",
     "style-loader": "^0.13.1",
+    "ts-node": "^2.1.0",
     "typescript": "^2.1.6",
     "webpack": "^2.2.1",
     "webpack-merge": "^2.4.0"
   },
-  "devDependencies": {
-  }
+  "devDependencies": {}
 }

--- a/specs/compile.json
+++ b/specs/compile.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "noImplicitAny": true,
+        "suppressImplicitAnyIndexErrors": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noEmit": true,
+        "typeRoots": [
+            "../node_modules/@types"
+        ]
+    },
+    "include": [
+        "**/*.ts",
+        "../shared/**/*.ts"
+    ],
+    "exclude": [
+        "node_modules"
+    ]
+}

--- a/specs/e2e/protractor.conf.ts
+++ b/specs/e2e/protractor.conf.ts
@@ -3,7 +3,7 @@ export let config = {
   baseUrl: "http://localhost:3000",
   framework: "mocha",
   specs: [
-    "./**/*.specs.js"
+    "./**/*.specs.ts"
   ],
   capabilities: {
     browserName: "chrome"

--- a/wallaby.conf.js
+++ b/wallaby.conf.js
@@ -1,6 +1,6 @@
-import * as path from 'path';
+const path = require('path');
 
-export = function (wallaby: any) {
+module.exports = function (wallaby) {
     process.env.NODE_PATH = process.env.NODE_PATH +
         path.delimiter + path.join(wallaby.localProjectDir, 'back-end', 'node_modules') +
         path.delimiter + path.join(wallaby.localProjectDir, 'front-end', 'node_modules');
@@ -8,12 +8,8 @@ export = function (wallaby: any) {
     return {
         files: [
             // Application code
-            { pattern: 'back-end/**/*.ts', load: false },
-            '!back-end/node_modules/**',
-            { pattern: 'front-end/**/*.ts', load: false },
-            '!front-end/node_modules/**',
-            { pattern: 'shared/**/*.ts', load: false },
-            { pattern: 'specs/**/*.ts', load: false },
+            { pattern: '*/**/*.ts', load: false },
+            '!*/node_modules/**',
             '!specs/unit/**/*.specs.ts'
         ],
         tests: [

--- a/webpack-helpers.js
+++ b/webpack-helpers.js
@@ -1,0 +1,6 @@
+const path = require('path');
+
+module.exports = function () {
+    let paths = [].slice.apply(arguments);
+    return path.join.apply(path, [__dirname].concat(paths));
+}

--- a/webpack-helpers.ts
+++ b/webpack-helpers.ts
@@ -1,5 +1,0 @@
-import * as path from 'path';
-
-export function root(...paths: string[]) {
-    return path.join.apply(path, [__dirname].concat(paths));
-}

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,19 +1,19 @@
-import * as webpack from 'webpack';
-import * as HtmlWebpackPlugin from 'html-webpack-plugin';
-import * as ExtractTextPlugin from 'extract-text-webpack-plugin';
-import * as CopyWebpackPlugin from 'copy-webpack-plugin';
-import { root } from './webpack-helpers';
+const webpack = require('webpack');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const root = require('./webpack-helpers');
 
-export default {
+module.exports = {
     entry: {
-        polyfills: './front-end/polyfills.js',
-        vendor: './front-end/vendor.js',
-        app: './front-end/main.js',
+        polyfills: './front-end/polyfills.ts',
+        vendor: './front-end/vendor.ts',
+        app: './front-end/main.ts',
         analytics: './front-end/analytics.js',
-        styles: './front-end/styles.js'
+        styles: './front-end/styles.ts'
     },
     resolve: {
-        extensions: ['.js']
+        extensions: ['.ts', '.js']
     },
     plugins: [
         new webpack.ProvidePlugin({
@@ -40,7 +40,14 @@ export default {
     module: {
         rules: [
             {
-                test: /\.component\.js$/,
+                test: /\.ts$/,
+                loaders: [{
+                    loader: 'awesome-typescript-loader',
+                    options: { configFileName: root('front-end', 'compile.json') }
+                }]
+            },
+            {
+                test: /\.component\.ts$/,
                 loaders: ['angular2-template-loader']
             },
             {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,8 +1,8 @@
-import * as webpackMerge from 'webpack-merge';
-import * as ExtractTextPlugin from 'extract-text-webpack-plugin';
-import commonConfig from './webpack.common';
+const webpackMerge = require('webpack-merge');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const commonConfig = require('./webpack.common');
 
-export = webpackMerge(commonConfig, {
+module.exports = webpackMerge(commonConfig, {
     devtool: 'inline-source-map',
 
     output: {

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,11 +1,11 @@
-import * as webpack from 'webpack';
-import * as webpackMerge from 'webpack-merge';
-import * as ExtractTextPlugin from 'extract-text-webpack-plugin';
-import commonConfig from './webpack.common';
+const webpack = require('webpack');
+const webpackMerge = require('webpack-merge');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const commonConfig = require('./webpack.common');
 
 const ENV = process.env.NODE_ENV = process.env.ENV = 'production';
 
-export = webpackMerge(commonConfig, {
+module.exports = webpackMerge(commonConfig, {
     devtool: 'source-map',
 
     output: {


### PR DESCRIPTION
- Convert files in root back to javascript so they don't require compiling and update .gitignore to include those JS files again
- Keep tsconfig.json in root so that it models the back-end, front-end and specs as a single project to provide intellisense and refactoring in Visual Studio Code.
- Add compile.json to back-end, front-end and specs projects with the configuration that they should be compiled with. These files are not called `tsconfig.json` because if they were then they would be picked up by Visual Studio Code and would result in the code base being recognised as 3 separate projects meaning that we would lose refactoring and intellisense support across the projects.
- Set noEmit to true on all tsconfig.json files to prevent any js files from being written to disk as they are not needed. The back-end now starts using ts-node, the front-end is packaged using awesome-typescript-loader, and the specs are run using wallaby in the editor or ts-node on the command line.
- Update package.json to strip out paths to node_modules because NPM runs commands with those modules loaded in its scope
- Simplify wallaby.conf.js

For https://github.com/SMH110/Pizza-website/issues/195