### PR TITLE
Heroku related package.json updates. See below:

### DIFF
--- a/back-end/package.json
+++ b/back-end/package.json
@@ -4,6 +4,15 @@
   "private": true,
   "scripts": {},
   "dependencies": {
+    "@types/body-parser": "0.0.33",
+    "@types/ejs": "^2.3.33",
+    "@types/express": "^4.0.34",
+    "@types/jsonwebtoken": "^7.2.0",
+    "@types/mongoose": "^4.7.3",
+    "@types/nodemailer": "^1.3.32",
+    "@types/passport": "^0.3.2",
+    "@types/passport-jwt": "^2.0.19",
+    "@types/request-promise": "^4.1.33",
     "body-parser": "^1.15.2",
     "ejs": "^2.5.5",
     "express": "^4.14.0",
@@ -17,14 +26,5 @@
     "request-promise": "^4.1.1"
   },
   "devDependencies": {
-    "@types/body-parser": "0.0.33",
-    "@types/ejs": "^2.3.33",
-    "@types/express": "^4.0.34",
-    "@types/jsonwebtoken": "^7.2.0",
-    "@types/mongoose": "^4.7.3",
-    "@types/nodemailer": "^1.3.32",
-    "@types/passport": "^0.3.2",
-    "@types/passport-jwt": "^2.0.19",
-    "@types/request-promise": "^4.1.33"
   }
 }

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -12,6 +12,10 @@
     "@angular/platform-browser": "~2.2.0",
     "@angular/platform-browser-dynamic": "~2.2.0",
     "@angular/router": "~3.2.0",
+    "@types/bootstrap": "^3.3.32",
+    "@types/google.analytics": "0.0.28",
+    "@types/jquery": "^2.0.40",
+    "@types/node": "^7.0.5",
     "bootstrap": "^3.3.7",
     "core-js": "^2.4.1",
     "jquery": "^3.1.1",
@@ -23,9 +27,5 @@
     "zone.js": "^0.6.26"
   },
   "devDependencies": {
-    "@types/bootstrap": "^3.3.32",
-    "@types/google.analytics": "0.0.28",
-    "@types/jquery": "^2.0.40",
-    "@types/node": "^7.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,39 +3,32 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "watch": "webpack --config webpack.dev.js --watch",
-    "package": "webpack --config webpack.prod.js",
-    "install-front-end": "cd front-end && npm install --production && npm install --only=development && cd ..",
-    "install-back-end": "cd back-end && npm install --production && npm install --only=development && cd ..",
-    "install": "npm run install-back-end && npm run install-front-end && npm run package",
+    "heroku-prebuild": "cd back-end && npm install && cd ../front-end && npm install && cd ..",
+    "heroku-postbuild": "npm run package",
     "unit": "mocha --compilers ts:ts-node/register specs/unit/**/*.specs.ts",
     "integration": "mocha --compilers ts:ts-node/register specs/integration/**/*.specs.ts",
     "e2e": "webdriver-manager update && ts-node node_modules/protractor/bin/protractor specs/e2e/protractor.conf.ts",
     "test": "npm run unit && npm run integration",
+    "watch": "webpack --config webpack.dev.js --watch",
+    "package": "webpack --config webpack.prod.js",
     "start": "ts-node --project back-end/compile.json back-end/app.ts"
   },
   "dependencies": {
-    "@types/chai": "^3.4.34",
     "@types/copy-webpack-plugin": "^4.0.0",
     "@types/extract-text-webpack-plugin": "^2.0.0",
     "@types/html-webpack-plugin": "^2.11.2",
-    "@types/mocha": "^2.2.38",
     "@types/node": "^7.0.0",
-    "@types/selenium-webdriver": "^2.53.39",
     "@types/webpack": "^2.2.6",
     "@types/webpack-merge": "0.0.4",
     "angular2-template-loader": "^0.6.0",
     "awesome-typescript-loader": "^3.0.8",
-    "chai": "^3.5.0",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.26.1",
     "extract-text-webpack-plugin": "2.0.0-beta.5",
     "file-loader": "^0.9.0",
     "html-loader": "^0.4.3",
     "html-webpack-plugin": "^2.16.1",
-    "mocha": "^3.2.0",
     "node-sass": "^4.5.0",
-    "protractor": "5.0.0",
     "raw-loader": "^0.5.1",
     "sass-loader": "^6.0.1",
     "style-loader": "^0.13.1",
@@ -44,5 +37,12 @@
     "webpack": "^2.2.1",
     "webpack-merge": "^2.4.0"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@types/chai": "^3.4.34",
+    "@types/mocha": "^2.2.38",
+    "@types/selenium-webdriver": "^2.53.39",
+    "chai": "^3.5.0",
+    "mocha": "^3.2.0",
+    "protractor": "5.0.0"
+  }
 }


### PR DESCRIPTION
- Move @types to dependencies as they are needed by the front-end packaging (webpack) and at runtime (by ts-node)
- Move testing dependencies to devDependencies as they aren't required for Heroku to generate a production build
- Move npm post-install scripts to heroku-prebuild and heroku-postbuild so that they are run by heroku only. This means we don't have to have a monolithic slow npm install command that does everything.

Deploy succeeded: https://dashboard.heroku.com/apps/godfather-pizza-qa/activity/builds/218421a7-e088-434b-86e6-96e161adf1ff